### PR TITLE
fixes

### DIFF
--- a/kube-aws-updater
+++ b/kube-aws-updater
@@ -25,22 +25,26 @@ kube_context=''
 aws_profile=''
 role=''
 registry_flag=''
+resume=''
 
 usage() {
   cat <<EOF
-Usage: $0 -c <kube_context> -p <aws_profile> -r [role] [-e]
+Usage: $0 -c <kube_context> -p <aws_profile> -s [retire_time_label] -r [role] [-e]
 
+  -s    Resume node rolling. Argument is retire_time label. If set, -r [role]
+        must also be set
   -e    Registry flag - set if cluster contains docker registry and
         needs to be moved prior to rest of the pods"
 EOF
 }
 
-while getopts 'c:p:r:eh' flag; do
+while getopts 'c:p:r:ehs:' flag; do
   case "${flag}" in
     c) kube_context="${OPTARG}" ;;
     p) aws_profile="${OPTARG}" ;;
     r) role="${OPTARG}" ;;
     e) registry_flag='true' ;;
+    s) resume="${OPTARG}" ;;
     h) usage && exit 0 ;;
     *) echo "Unexpected option ${flag}" && usage && exit 1 ;;
   esac
@@ -73,7 +77,13 @@ if [[ -z "${kube_context}" ]]; then
   exit 1
 fi
 
-aws_opts=
+if [[ -n "${resume}" ]] && [[ -z "${role}" ]] ; then
+  echo "If you are resuming, you need to provide a role"
+  usage
+  exit 1
+fi
+
+aws_opts=""
 if [[ -n "${aws_profile}" ]]; then
   if aws configure list --profile ${aws_profile} &> /dev/null; then
     aws_opts="--profile=${aws_profile}"
@@ -116,11 +126,11 @@ kill_node() {
 
   echo "---------- ${node} ----------"
   echo "draining ${node}..."
-  time kubectl --context=${kube_context} drain ${node} --ignore-daemonsets --force --delete-local-data
+  time timeout 600 kubectl --context=${kube_context} drain ${node} --ignore-daemonsets --force --delete-local-data || echo "draining failed (operator eviction or timeout [10m]), proceeding with shutdown"
   local instance_id=$(aws ${aws_opts} --output=json ec2 describe-instances --filters "Name=network-interface.private-dns-name,Values=${node}" \
     | jq -r '.Reservations[].Instances[].InstanceId')
   echo "terminating ${node} with instance-id ${instance_id}"
-  time aws ${aws_opts} ec2 terminate-instances --instance-ids=${instance_id}
+  aws ${aws_opts} ec2 terminate-instances --instance-ids=${instance_id}
   echo "----------------------------------------------------------------------"
 }
 
@@ -175,6 +185,18 @@ update() {
   label_for_cycling ${role}
   cycle_nodes ${role}
 }
+
+resume() {
+  local old_nodes=$(kubectl --context="${kube_context}" get nodes -l role="${role}",retiring="${resume}" -o json | jq -r '.items[].metadata.name')
+  for old_node in ${old_nodes}; do
+    kill_node ${old_node}
+  done
+}
+
+if [[ -n "${resume}" ]]; then
+  resume
+  exit 0
+fi
 
 if [[ -n "${role}" ]]; then
   update ${role}

--- a/kube-aws-updater
+++ b/kube-aws-updater
@@ -34,7 +34,7 @@ Usage: $0 -c <kube_context> -p <aws_profile> -s [retire_time_label] -r [role] [-
   -s    Resume node rolling. Argument is retire_time label. If set, -r [role]
         must also be set
   -e    Registry flag - set if cluster contains docker registry and
-        needs to be moved prior to rest of the pods"
+        needs to be moved prior to rest of the pods
 EOF
 }
 
@@ -98,14 +98,17 @@ echo "kube cluster :: ${kube_context}"
 
 handle_registry() {
   if [[ "${registry_flag}" == "true" ]]; then
-    local kube_opts="--context=${kube_context} -nsys-registry"
+    local ns="sys-registry"
+    local pod_pattern="docker-registry"
+    local kube_opts="--context=${kube_context} -n${ns}"
     local registry_pod=$(kubectl ${kube_opts} get pod \
-      | grep docker-registry \
+      | grep ${pod_pattern} \
       | awk '{print $1}')
     kubectl ${kube_opts} delete pod ${registry_pod}
 
-    until kubectl ${kube_opts} get pod | grep docker-registry | grep Running &> /dev/null; do
-      kubectl ${kube_opts} get pod | grep docker-registry
+    until kubectl ${kube_opts} get pod | grep ${pod_pattern} | grep Running &> /dev/null; do
+      sleep 4
+      kubectl ${kube_opts} get pod | grep ${pod_pattern}
     done
   fi
 }


### PR DESCRIPTION
- Add a resume function [-s] this will continue killing labelled nodes
   if the scripted failed and exited
 - Add a timeout to drain, certain pods don't react to SIGTERM/SIGKILL
   and the drain effectively halts. Add a timeout to the drain and proceed
   with termination if the timeout is reached
 - Similarly if the drain has failed, for example the operator can't
   handle draining (existing bug) or timeout is reached, proceed with
   instance termination