### PR TITLE
Add a sleep if kubectl drain errors

### DIFF
--- a/kube-aws-updater
+++ b/kube-aws-updater
@@ -131,16 +131,29 @@ label_for_cycling() {
 
 kill_node() {
   local node=$1
+  local failDrain=false
 
-  echo "---------- ${node} ----------"
-  echo "draining ${node}..."
-  time timeout ${timeout} kubectl --context=${kube_context} drain ${node} --ignore-daemonsets --force --delete-local-data \
-    || echo "draining failed (operator eviction or timeout [${timeout}s]), proceeding with shutdown"
+  set +e
+  time timeout ${timeout} kubectl --context=${kube_context} drain ${node} --ignore-daemonsets --force --delete-local-data
+  local rc=$?
+  set -e
+  if [[ ${rc} == 0 ]]; then
+    echo "drained sucessfully"
+  elif [[ ${rc} == 124 ]]; then
+    echo "timeout of ${timeout} seconds has been reached, continuing..."
+  else
+    echo "kubectl drain exit error: ${rc}"
+    failDrain=true
+  fi
+
   local instance_id=$(aws ${aws_opts} --output=json ec2 describe-instances --filters "Name=network-interface.private-dns-name,Values=${node}" \
     | jq -r '.Reservations[].Instances[].InstanceId')
   echo "terminating ${node} with instance-id ${instance_id}"
   aws ${aws_opts} ec2 terminate-instances --instance-ids=${instance_id}
-  echo "----------------------------------------------------------------------"
+  if [[ ${failDrain} == true ]]; then
+    echo "Error on drain, terminating and sleeping ${timeout} seconds"
+    sleep ${timeout}
+  fi
 }
 
 cycle_nodes() {


### PR DESCRIPTION
kubectl drain can fail if the node is running an operator managed
resource, see: https://github.com/kubernetes/kubernetes/issues/57049

If this this happens we should sleep for the period of `${timeout}` value
after terminating the node to allow the services to start before we
start draining the next node.