### PR TITLE
Check that AZs are balanced after an ASG is scaled

### DIFF
--- a/kube-aws-updater
+++ b/kube-aws-updater
@@ -28,7 +28,7 @@ resume=''
 timeout=600
 
 log() {
-  echo "[$(date +'%Y-%m-%dT%H:%M:%S')]: $@" >&2
+  echo -e "[$(date +'%Y-%m-%dT%H:%M:%S')]: $@" >&2
 }
 
 usage() {
@@ -208,6 +208,23 @@ cycle_nodes() {
     "AZRebalance" \
     "AlarmNotification" \
     "ScheduledActions"
+
+  # check that nodes are balanced across three AZs
+  local nodes_per_zone
+  nodes_per_zone=$(kubectl --context "${kube_context}" get nodes -lrole="${role}" --no-headers -ocustom-columns=':.metadata.labels.failure-domain\.beta\.kubernetes\.io\/zone' |\
+      sort |\
+      uniq -c)
+  local npz
+  readarray -t npz < <(echo "${nodes_per_zone}" | awk '{print $1}')
+  if [ "${#npz[@]}" -ne 3 ]; then
+      log "Expected nodes across three zones. Node distribution:\n$nodes_per_zone\nCannot proceed, exiting"
+      exit 1
+  fi
+  # shellcheck disable=SC2252
+  if [ "${npz[0]}" != "${npz[1]}" ] || [ "${npz[0]}" != "${npz[2]}" ] || [ "${npz[1]}" != "${npz[2]}" ]; then
+      log "Nodes are not perfectly balanced across zones. Node distribution:\n$nodes_per_zone\nCannot proceed, exiting"
+      exit 1
+  fi
 
   # - drain/terminate labelled nodes (sequentially)
   local old_nodes=$(retry kubectl --context="${kube_context}" get nodes -l role="${role}",retiring="${retire_time}" -o json | jq -r '.items[].metadata.name')


### PR DESCRIPTION
AWS does not guarantee that nodes will be balanced across AZ when
scaling up (which can happen, for example, if one zone does not have
enough capacity at the time). For an AWS cluster that uses EBS volumes,
this can be problematic and cause Pods to be unschedulable when one zone
has reduced capacity. This check will abort draining of the nodes if it
detects that the nodes are not evenly spread across three AZs.