### PR TITLE
Add readarray to requirements and update shebang

### DIFF
--- a/kube-aws-updater
+++ b/kube-aws-updater
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Shell style guide: https://google.github.io/styleguide/shell.xml
 
@@ -62,6 +62,7 @@ deps="
   aws
   timeout
   xargs
+  readarray
 "
 
 missing_deps=""


### PR DESCRIPTION
OSX ships with v3.x bash which does not support readarray.

Additionally, changing the shebang should allow custom bash
installations to be used automatically as long as they're in the PATH.