### PR TITLE
Check that cloud-controller has created topology labels

### DIFF
--- a/kube-aws-updater
+++ b/kube-aws-updater
@@ -237,6 +237,11 @@ assert_asg_balance() {
   local role=$1
   local grace_delta=1
 
+  # Check that topology node labels are populated by the respective controller
+  while [[ $(kubectl --context "${kube_context}" get nodes -lrole="master" --no-headers -ocustom-columns=':.metadata.labels.topology\.kubernetes\.io\/zone' | grep "<none>" | wc -l) -gt 0 ]]; do
+    echo "Waiting for cloud controller to populate topology.kubernetes.io/zone label on all nodes";
+    sleep 1;
+  done
   # check that nodes are balanced across three AZs
   local nodes_per_zone
   nodes_per_zone=$(kubectl --context "${kube_context}" get nodes -l "role=${role}" --no-headers -ocustom-columns=':.metadata.labels.topology\.kubernetes\.io\/zone' |\


### PR DESCRIPTION
To avoid "none" values while checking if nodes are balanced before cloud controller init